### PR TITLE
Adding usb-role-switch; to make USB OTG work

### DIFF
--- a/arch/arm64/boot/dts/qcom/sm8475-nothing-pong.dts
+++ b/arch/arm64/boot/dts/qcom/sm8475-nothing-pong.dts
@@ -1000,6 +1000,7 @@
 &usb_1_dwc3 {
 	dr_mode = "otg";
 	maximum-speed = "high-speed";
+	usb-role-switch;
 	/* Remove USB3 phy */
 	phys = <&usb_1_hsphy>;
 	phy-names = "usb2-phy";


### PR DESCRIPTION
Added `usb-role-switch;` to the USB node in the device tree to make OTG work properly.
Tested on Phone (2), Arch Linux ARM